### PR TITLE
Fix release package versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,16 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: nfpm pkg --packager rpm --target dist/
 
+      - name: Verify OS package versions
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          ls -lah dist/
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            test -f "dist/cdi-health_${VERSION}_all.deb"
+            test -f "dist/cdi-health-${VERSION}-1.noarch.rpm"
+          fi
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reorganized the health specification into drive-class sections for SATA HDD, SAS HDD, SATA SSD, SAS SSD, and NVMe SSD.
 - Added openSeaChest health-check workflow notes to clarify SMART warnings, unavailable SMART checks, DST failure modes, Device Statistics preference, and telemetry-only counters.
 - Updated the README health summary to point to the main-repo CDI health spec and mirror the drive-class grading model.
+- Fixed release packaging so `.deb` and `.rpm` package versions come from the pushed git tag.
 
 ### Technical Details
 - Self-test implementation follows NVMe Base Specification 2.3

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -8,7 +8,7 @@
 name: cdi-health
 arch: all
 platform: linux
-version: ${VERSION:-0.0.0}
+version: ${VERSION}
 section: utils
 priority: optional
 maintainer: Circular Drive Initiative <nick.hayhurst@interactdc.com>


### PR DESCRIPTION
## Summary
- Fix nFPM version interpolation so OS packages use the release tag version.
- Add a tag-build assertion that `.deb` and `.rpm` filenames include the tag version before uploading release artifacts.

## Test plan
- [x] pre-commit check-yaml on release workflow and nfpm config
- [x] pre-commit end-of-file-fixer on touched files