### PR TITLE
Fix package version verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,8 +89,12 @@ jobs:
         run: |
           ls -lah dist/
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            test -f "dist/cdi-health_${VERSION}_all.deb"
-            test -f "dist/cdi-health-${VERSION}-1.noarch.rpm"
+            package_version="${VERSION}"
+            if [[ "${package_version}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+              package_version="${package_version}.0"
+            fi
+            test -f "dist/cdi-health_${package_version}_all.deb"
+            test -f "dist/cdi-health-${package_version}-1.noarch.rpm"
           fi
 
       - name: Upload build artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added openSeaChest health-check workflow notes to clarify SMART warnings, unavailable SMART checks, DST failure modes, Device Statistics preference, and telemetry-only counters.
 - Updated the README health summary to point to the main-repo CDI health spec and mirror the drive-class grading model.
 - Fixed release packaging so `.deb` and `.rpm` package versions come from the pushed git tag.
+- Accounted for nFPM's normalized SemVer package filenames, e.g. tag `v0.9` produces OS packages named `0.9.0`.
 
 ### Technical Details
 - Self-test implementation follows NVMe Base Specification 2.3


### PR DESCRIPTION
## Summary
- Update the release package version guard to account for nFPM normalizing two-part tag versions like `0.9` to `0.9.0` in `.deb`/`.rpm` filenames.

## Test plan
- [x] pre-commit check-yaml on release workflow
- [x] pre-commit end-of-file-fixer on touched files