### PR TITLE
Fix GHCR flat image names and release visibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,7 @@ jobs:
         id: meta-api
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}/cdi-health-api
+          images: ghcr.io/circulardrives/cdi-health-api
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -174,7 +174,7 @@ jobs:
           platforms: linux/amd64
           push: false
           load: true
-          tags: ghcr.io/${{ github.repository }}/cdi-health-api:ci
+          tags: ghcr.io/circulardrives/cdi-health-api:ci
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=cdi-health-api
@@ -185,7 +185,7 @@ jobs:
         id: meta-dashboard
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}/cdi-health-dashboard
+          images: ghcr.io/circulardrives/cdi-health-dashboard
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -213,27 +213,24 @@ jobs:
           platforms: linux/amd64
           push: false
           load: true
-          tags: ghcr.io/${{ github.repository }}/cdi-health-dashboard:ci
+          tags: ghcr.io/circulardrives/cdi-health-dashboard:ci
           cache-from: type=gha,scope=cdi-health-dashboard
           cache-to: type=gha,mode=max,scope=cdi-health-dashboard
 
       - name: Verify API image (CI)
         if: steps.version.outputs.push != 'true'
         run: |
-          docker run --rm ghcr.io/${{ github.repository }}/cdi-health-api:ci \
+          docker run --rm ghcr.io/circulardrives/cdi-health-api:ci \
             python -c "import cdi_health; import fastapi; print('ok')"
 
       - name: Set GHCR package visibility to public
         if: steps.version.outputs.push == 'true'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          packages=(
-            "cdi-grading-tool%2Fcdi-health-api"
-            "cdi-grading-tool%2Fcdi-health-dashboard"
-          )
-          for pkg in "${packages[@]}"; do
+          for pkg in cdi-health-api cdi-health-dashboard; do
             echo "Setting ${pkg} visibility to public..."
             gh api --method PATCH "/orgs/circulardrives/packages/container/${pkg}" \
               -f visibility=public \
@@ -259,8 +256,8 @@ jobs:
             echo
             echo "Multi-arch (\`linux/amd64\`, \`linux/arm64\`) images are published to GHCR:"
             echo
-            echo "- \`ghcr.io/${{ github.repository }}/cdi-health-api:${version}\`"
-            echo "- \`ghcr.io/${{ github.repository }}/cdi-health-dashboard:${version}\`"
+            echo "- \`ghcr.io/circulardrives/cdi-health-api:${version}\`"
+            echo "- \`ghcr.io/circulardrives/cdi-health-dashboard:${version}\`"
             echo
             echo '```bash'
             echo "docker compose -f deploy/docker/docker-compose.ghcr.yml up -d"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -183,8 +183,8 @@ Linux release packages are built in CI (see `.github/workflows/release.yml`) usi
 
 The same release workflow builds and pushes multi-arch images on each `v*` tag:
 
-- `ghcr.io/circulardrives/cdi-grading-tool/cdi-health-api`
-- `ghcr.io/circulardrives/cdi-grading-tool/cdi-health-dashboard`
+- `ghcr.io/circulardrives/cdi-health-api`
+- `ghcr.io/circulardrives/cdi-health-dashboard`
 
 Dockerfiles live under `deploy/docker/`. Pull requests build images in CI (amd64, no push) to catch Dockerfile regressions.
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ Open http://127.0.0.1:3000 (mock fixtures by default). Live drive scanning: `./s
 
 Official `v*` releases publish multi-arch images (`linux/amd64`, `linux/arm64`):
 
-- `ghcr.io/circulardrives/cdi-grading-tool/cdi-health-api`
-- `ghcr.io/circulardrives/cdi-grading-tool/cdi-health-dashboard`
+- `ghcr.io/circulardrives/cdi-health-api`
+- `ghcr.io/circulardrives/cdi-health-dashboard`
 
 ```shell
 git clone https://github.com/circulardrives/cdi-grading-tool.git

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -32,8 +32,8 @@ CDI_VERSION=0.9.0 docker compose -f deploy/docker/docker-compose.ghcr.yml up -d
 
 Images:
 
-- `ghcr.io/circulardrives/cdi-grading-tool/cdi-health-api`
-- `ghcr.io/circulardrives/cdi-grading-tool/cdi-health-dashboard`
+- `ghcr.io/circulardrives/cdi-health-api`
+- `ghcr.io/circulardrives/cdi-health-dashboard`
 
 See [Technician deployment](../docs/TECHNICIAN_DEPLOYMENT.md) for hardware scanning, env vars, and troubleshooting.
 

--- a/deploy/docker/docker-compose.ghcr.yml
+++ b/deploy/docker/docker-compose.ghcr.yml
@@ -9,7 +9,7 @@ name: cdi-health
 
 services:
   api:
-    image: ghcr.io/circulardrives/cdi-grading-tool/cdi-health-api:${CDI_VERSION:-latest}
+    image: ghcr.io/circulardrives/cdi-health-api:${CDI_VERSION:-latest}
     container_name: cdi-health-api
     environment:
       CDI_HEALTH_API_ALLOW_NON_ROOT: "1"
@@ -35,7 +35,7 @@ services:
     restart: unless-stopped
 
   dashboard:
-    image: ghcr.io/circulardrives/cdi-grading-tool/cdi-health-dashboard:${CDI_VERSION:-latest}
+    image: ghcr.io/circulardrives/cdi-health-dashboard:${CDI_VERSION:-latest}
     container_name: cdi-health-dashboard
     ports:
       - "${DASHBOARD_PORT:-3000}:80"

--- a/docs/TECHNICIAN_DEPLOYMENT.md
+++ b/docs/TECHNICIAN_DEPLOYMENT.md
@@ -31,8 +31,8 @@ docker compose -f deploy/docker/docker-compose.ghcr.yml up -d
 
 Images are built and pushed on each `v*` tag release to (public GHCR packages):
 
-- `ghcr.io/circulardrives/cdi-grading-tool/cdi-health-api`
-- `ghcr.io/circulardrives/cdi-grading-tool/cdi-health-dashboard`
+- `ghcr.io/circulardrives/cdi-health-api`
+- `ghcr.io/circulardrives/cdi-health-dashboard`
 
 No `docker login` required for public pulls.
 


### PR DESCRIPTION
## Summary
- Publish images as `ghcr.io/circulardrives/cdi-health-api` and `cdi-health-dashboard` (flat names; fixes visibility API 404)
- Make GHCR public-visibility step `continue-on-error` so releases complete even if org policy blocks automated visibility
- Update compose/docs to match new image paths

## Test plan
- [ ] Merge and tag `v0.9.3`
- [ ] Verify release workflow completes (including GitHub Release asset upload)
- [ ] `docker logout ghcr.io && CDI_VERSION=0.9.3 docker compose -f deploy/docker/docker-compose.ghcr.yml pull`


Made with [Cursor](https://cursor.com)