### PR TITLE
Docker host-network overlay for LAN discovery (0.9.4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,9 +260,10 @@ jobs:
             echo "- \`ghcr.io/circulardrives/cdi-health-dashboard:${version}\`"
             echo
             echo '```bash'
-            echo "docker compose -f deploy/docker/docker-compose.ghcr.yml up -d"
-            echo "# or pin this release:"
+            echo "# mock demo:"
             echo "CDI_VERSION=${version} docker compose -f deploy/docker/docker-compose.ghcr.yml up -d"
+            echo "# LAN discovery (host network API):"
+            echo "CDI_VERSION=${version} docker compose -f deploy/docker/docker-compose.ghcr.yml -f deploy/docker/docker-compose.host.yml up -d"
             echo '```'
           } > "$RUNNER_TEMP/release-containers.md"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.4] - 2026-06-21
+
 ### Added
-- **Docker Compose** stack under `deploy/docker/` for API + dashboard without local Python/bun/systemd setup (mock demo by default; optional hardware overlay for live drive scanning).
-- `./scripts/docker-up.sh` helper for `docker compose up`.
-- **Release workflow** publishes multi-arch Docker images to GHCR on each `v*` tag (`cdi-health-api`, `cdi-health-dashboard`); use `deploy/docker/docker-compose.ghcr.yml` to run published images.
+- **Docker host-network overlay** (`deploy/docker/docker-compose.host.yml`): API binds on the host interface so **Discover** can scan the lab LAN for remote grading benches running `cdi-health-api`. Use `./scripts/docker-up.sh --host` or add the overlay to `docker-compose.ghcr.yml`.
+
+### Changed
+- Published dashboard image defaults to live-scan UI mode (`VITE_CDI_USE_MOCK_DATA=0`); mock demos still use fixture data from the API container environment.
 
 ## [0.9.0] - 2026-05-24
 

--- a/README.md
+++ b/README.md
@@ -65,40 +65,43 @@ Choose the path that matches your goal:
 
 | Goal | Method |
 | ---- | ------ |
-| Try the **dashboard + API** (mock data) | [Docker Compose](#docker-compose-recommended-for-dashboard) or [GHCR release images](#github-container-registry-ghcr) |
-| Install **CLI on a grading host** | [`.deb` package](#debianubuntu-deb-release-builds--recommended-for-grading-hosts) |
+| **Try the dashboard** (mock data) | [Docker / GHCR](#docker-compose-mock-demo) |
+| **Find grading benches on the LAN** | [Docker + host overlay](#docker-compose-mock-demo) |
+| **Real drive scans** on a grading bench | [`.deb` package](#debianubuntu-deb--for-grading-benches-with-real-drives-cli--api) |
 | **Develop** or patch the codebase | [From source](#from-source) |
 
-### Docker Compose (recommended for dashboard)
+### Docker Compose (mock demo)
 
-Requires [Docker](https://docs.docker.com/get-docker/) with Compose v2. No local Python, bun, or npm.
+Requires [Docker](https://docs.docker.com/get-docker/) with Compose v2. No Python, bun, or npm.
 
-**Build locally:**
-
-```shell
-git clone https://github.com/circulardrives/cdi-grading-tool.git
-cd cdi-grading-tool
-./scripts/docker-up.sh --build
-```
-
-Open http://127.0.0.1:3000 (mock fixtures by default). Live drive scanning: `./scripts/docker-up.sh --hardware --build` (Linux host with `/dev` access).
-
-**GitHub Container Registry (GHCR)**
-
-Official `v*` releases publish multi-arch images (`linux/amd64`, `linux/arm64`):
-
-- `ghcr.io/circulardrives/cdi-health-api`
-- `ghcr.io/circulardrives/cdi-health-dashboard`
+**Mock demo** (fixtures, no drives):
 
 ```shell
 git clone https://github.com/circulardrives/cdi-grading-tool.git
 cd cdi-grading-tool
-docker compose -f deploy/docker/docker-compose.ghcr.yml up -d
+
+CDI_VERSION=0.9.4 docker compose -f deploy/docker/docker-compose.ghcr.yml up -d
 ```
 
-Pin a release: `CDI_VERSION=0.9.0 docker compose -f deploy/docker/docker-compose.ghcr.yml up -d`
+Open http://127.0.0.1:3000
 
-Full options (hardware overlay, env vars, troubleshooting): [Technician deployment](docs/TECHNICIAN_DEPLOYMENT.md).
+**LAN discovery** (find remote grading benches on the network):
+
+```shell
+CDI_VERSION=0.9.4 docker compose \
+  -f deploy/docker/docker-compose.ghcr.yml \
+  -f deploy/docker/docker-compose.host.yml up -d
+```
+
+Open http://127.0.0.1:3000 → **Discover**. Requires port **8844** free on your machine.
+
+Stop either stack: `docker compose -f deploy/docker/docker-compose.ghcr.yml down` (add `-f deploy/docker/docker-compose.host.yml` if you used the host overlay).
+
+Images: `ghcr.io/circulardrives/cdi-health-api` and `ghcr.io/circulardrives/cdi-health-dashboard` (multi-arch, published on each `v*` release).
+
+To build locally instead of pulling: `./scripts/docker-up.sh --build` (add `--host` for LAN discovery).
+
+Full options: [Technician deployment](docs/TECHNICIAN_DEPLOYMENT.md).
 
 **From PyPI**
 
@@ -118,7 +121,7 @@ pip install -e .
 pip install -e .[dev,api]
 ```
 
-**Debian/Ubuntu `.deb` (release builds)** — recommended for bare-metal grading hosts
+**Debian/Ubuntu `.deb`** — for **grading benches** with real drives (CLI + API)
 
 Prebuilt packages are on [GitHub Releases](https://github.com/circulardrives/cdi-grading-tool/releases).
 
@@ -158,12 +161,22 @@ For latest Seagate OpenSeaChest or a newer **nvme-cli** with OCP support when ap
 sudo ./scripts/install-host-dependencies.sh --latest-openseachest --build-nvme-cli
 ```
 
-**Enable the local API** (optional, for dashboards):
+**Enable the local API** (optional, for dashboards and LAN discovery):
 
 ```shell
 sudo systemctl enable --now cdi-health-api
 curl -s http://127.0.0.1:8844/api/v1/health
 ```
+
+To appear in **Discover** from a technician laptop running Docker (host overlay), bind the API on the lab network:
+
+```shell
+sudo mkdir -p /etc/systemd/system/cdi-health-api.service.d
+printf '[Service]\nExecStart=\nExecStart=/usr/local/bin/cdi-health-api --host 0.0.0.0 --port 8844 --data-dir /var/lib/cdi-health\n' | sudo tee /etc/systemd/system/cdi-health-api.service.d/override.conf
+sudo systemctl daemon-reload && sudo systemctl restart cdi-health-api
+```
+
+Use only on trusted lab networks.
 
 **Verify grading:**
 
@@ -287,17 +300,18 @@ Optional: `--api-token …` and header `X-API-Token`. Endpoints include `/api/v1
 
 Browser-based **grading console** for bench technicians: **Fleet Status**, **Hosts**, **Discover**, **Scan**, **Drive Health**, **Health Reports**, and **NVMe Self-Test**. Source lives in `dashboard/` (Vite + React + shadcn/ui monorepo, managed with **bun**).
 
-The dashboard is **separate from the `.deb` package** — the release install provides `cdi-health` and optional `cdi-health-api` on grading hosts. For the UI, prefer **Docker** (above) or the options below.
+The dashboard is **separate from the `.deb` package**. Install `.deb` on grading benches; run the UI via **Docker/GHCR** on a technician laptop (mock demo or LAN discovery with the host overlay).
 
-### Run with Docker (easiest)
+### Run with Docker
 
 ```shell
-./scripts/docker-up.sh --build
-# or published images:
-docker compose -f deploy/docker/docker-compose.ghcr.yml up -d
+CDI_VERSION=0.9.4 docker compose -f deploy/docker/docker-compose.ghcr.yml up -d
+# LAN discovery:
+CDI_VERSION=0.9.4 docker compose -f deploy/docker/docker-compose.ghcr.yml \
+  -f deploy/docker/docker-compose.host.yml up -d
 ```
 
-Opens http://127.0.0.1:3000 with mock data. See [Technician deployment](docs/TECHNICIAN_DEPLOYMENT.md).
+See [Technician deployment](docs/TECHNICIAN_DEPLOYMENT.md).
 
 ### Local development (bun)
 
@@ -322,7 +336,7 @@ bun run dev
 
 Start `cdi-health-api` separately (or use the mock launcher above). Set `VITE_CDI_USE_MOCK_DATA=0` in `.env.local` for live device scans.
 
-**Remote grading host** (laptop UI → host API):
+**Remote grading host** (laptop UI → bench API):
 
 ```shell
 cd dashboard

--- a/deploy/docker/Dockerfile.api
+++ b/deploy/docker/Dockerfile.api
@@ -12,7 +12,7 @@ WORKDIR /app
 COPY pyproject.toml README.md LICENSE ./
 COPY src ./src
 
-ARG VERSION=0.9.0
+ARG VERSION=0.9.4
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
 RUN pip install --no-cache-dir ".[api]"
 

--- a/deploy/docker/Dockerfile.dashboard
+++ b/deploy/docker/Dockerfile.dashboard
@@ -8,7 +8,7 @@ COPY dashboard/apps ./apps
 COPY dashboard/packages ./packages
 
 ARG VITE_CDI_API_BASE_URL=/api/cdi
-ARG VITE_CDI_USE_MOCK_DATA=1
+ARG VITE_CDI_USE_MOCK_DATA=0
 ARG VITE_CDI_API_TOKEN=
 ARG VITE_CDI_MOCK_DATA_PATH=src/cdi_health/mock_data
 

--- a/deploy/docker/docker-compose.ghcr.yml
+++ b/deploy/docker/docker-compose.ghcr.yml
@@ -3,7 +3,11 @@
 #   docker compose -f deploy/docker/docker-compose.ghcr.yml up -d
 #
 # Pin a release:
-#   CDI_VERSION=0.9.0 docker compose -f deploy/docker/docker-compose.ghcr.yml up -d
+#   CDI_VERSION=0.9.4 docker compose -f deploy/docker/docker-compose.ghcr.yml up -d
+#
+# LAN discovery overlay:
+#   CDI_VERSION=0.9.4 docker compose -f deploy/docker/docker-compose.ghcr.yml \
+#     -f deploy/docker/docker-compose.host.yml up -d
 
 name: cdi-health
 

--- a/deploy/docker/docker-compose.host.yml
+++ b/deploy/docker/docker-compose.host.yml
@@ -1,0 +1,24 @@
+# Overlay: API uses the host network so LAN discovery sees lab interfaces.
+# Dashboard stays bridged and proxies to the API on the host via host.docker.internal.
+#
+# Mock demo (default):
+#   docker compose -f deploy/docker/docker-compose.ghcr.yml up -d
+#
+# LAN discovery (find remote grading benches on the network):
+#   docker compose -f deploy/docker/docker-compose.ghcr.yml \
+#     -f deploy/docker/docker-compose.host.yml up -d
+#
+# Requires Docker Compose v2.1+ (host-gateway). Linux and Docker Desktop supported.
+# Ensure port 8844 is free on the host (stop local cdi-health-api if installed).
+
+services:
+  api:
+    network_mode: host
+    volumes:
+      - cdi-api-data:/var/lib/cdi-health
+
+  dashboard:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - ./nginx.host.conf:/etc/nginx/conf.d/default.conf:ro

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       context: ../..
       dockerfile: deploy/docker/Dockerfile.dashboard
       args:
-        VITE_CDI_USE_MOCK_DATA: ${VITE_CDI_USE_MOCK_DATA:-1}
+        VITE_CDI_USE_MOCK_DATA: ${VITE_CDI_USE_MOCK_DATA:-0}
         VITE_CDI_API_TOKEN: ${CDI_HEALTH_API_TOKEN:-}
     container_name: cdi-health-dashboard
     ports:

--- a/deploy/docker/nginx.host.conf
+++ b/deploy/docker/nginx.host.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /api/cdi/ {
+        proxy_pass http://host.docker.internal:8844/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/docs/TECHNICIAN_DEPLOYMENT.md
+++ b/docs/TECHNICIAN_DEPLOYMENT.md
@@ -8,62 +8,52 @@ This guide covers three common setups:
 
 Both bare-metal options expect **Linux** with access to storage tooling (see below).
 
-## Option A — Docker Compose (recommended for dashboard)
+## Option A — Docker Compose
 
-Requires [Docker](https://docs.docker.com/get-docker/) with Compose v2. No local Python, bun, or npm install.
+Requires [Docker](https://docs.docker.com/get-docker/) with Compose v2. No local Python, bun, or npm.
 
-**Demo / mock data** (try the UI without physical drives):
+### Mock demo (GHCR, no build)
 
 ```bash
 git clone https://github.com/circulardrives/cdi-grading-tool.git
 cd cdi-grading-tool
-./scripts/docker-up.sh --build
+
+CDI_VERSION=0.9.4 docker compose -f deploy/docker/docker-compose.ghcr.yml up -d
 ```
 
-Open http://127.0.0.1:3000
+Open http://127.0.0.1:3000 — bundled mock fixtures, no physical drives.
 
-**Published release images (GHCR, no local build):**
+### LAN discovery (find remote grading benches)
+
+Runs the API on the **host network** so **Discover** can probe the lab LAN for systems running `cdi-health-api` (e.g. from the `.deb` on a bench). Port **8844** must be free on your machine.
 
 ```bash
-docker compose -f deploy/docker/docker-compose.ghcr.yml up -d
-# pin a version: CDI_VERSION=0.9.0 docker compose -f deploy/docker/docker-compose.ghcr.yml up -d
+CDI_VERSION=0.9.4 docker compose \
+  -f deploy/docker/docker-compose.ghcr.yml \
+  -f deploy/docker/docker-compose.host.yml up -d
 ```
 
-Images are built and pushed on each `v*` tag release to (public GHCR packages):
+Open http://127.0.0.1:3000 → **Discover**.
+
+Images (`linux/amd64`, `linux/arm64`):
 
 - `ghcr.io/circulardrives/cdi-health-api`
 - `ghcr.io/circulardrives/cdi-health-dashboard`
 
 No `docker login` required for public pulls.
 
-Or without the helper script:
-
-```bash
-docker compose -f deploy/docker/docker-compose.yml up --build
-```
-
-**Live drive scanning** on the Docker host (Linux, root in container, `/dev` mounted):
-
-```bash
-./scripts/docker-up.sh --hardware --build
-# or: docker compose -f deploy/docker/docker-compose.yml \
-#       -f deploy/docker/docker-compose.hardware.yml up --build
-```
-
-Copy `deploy/docker/.env.example` to `deploy/docker/.env` to set `DASHBOARD_PORT` or an optional `CDI_HEALTH_API_TOKEN`.
-
 Stop:
 
 ```bash
-docker compose -f deploy/docker/docker-compose.yml down
+docker compose -f deploy/docker/docker-compose.ghcr.yml \
+  -f deploy/docker/docker-compose.host.yml down
 ```
 
-**Notes:**
+**Build locally** (optional): `./scripts/docker-up.sh --build` or `./scripts/docker-up.sh --host --build`
 
-- Default stack runs the API in mock mode with bundled fixtures — good for training and UI smoke tests.
-- Hardware overlay runs the API as root with `privileged: true` and host `/dev` access; use only on trusted grading hosts.
-- PDF reports still need WeasyPrint inside the API image if you require `--format pdf` (HTML/CSV work without it).
-- For production grading benches that are not containerized, use Option B (`.deb`) or Option C (git + systemd) below.
+Copy `deploy/docker/.env.example` to `deploy/docker/.env` to set `DASHBOARD_PORT` or an optional `CDI_HEALTH_API_TOKEN`.
+
+For live drive scanning on the bench itself, use Option B (`.deb`) below.
 
 ---
 
@@ -111,7 +101,17 @@ Layout:
 
 Systemd unit **`cdi-health-api.service`** may be installed under `/usr/lib/systemd/system/`; enable it if you want the API on boot (see below). It stores state in **`/var/lib/cdi-health`** and does not require a git clone.
 
-For **dashboard + API** together, use **Option A (Docker Compose)**, `./scripts/start-local-mock.sh` from a dev clone, or a separate dashboard build from Option C.
+**LAN discovery:** the default unit binds to `127.0.0.1` only. For a bench to appear in **Discover** from a technician laptop (Docker host overlay), expose the API on the lab network:
+
+```bash
+sudo mkdir -p /etc/systemd/system/cdi-health-api.service.d
+printf '[Service]\nExecStart=\nExecStart=/usr/local/bin/cdi-health-api --host 0.0.0.0 --port 8844 --data-dir /var/lib/cdi-health\n' | sudo tee /etc/systemd/system/cdi-health-api.service.d/override.conf
+sudo systemctl daemon-reload && sudo systemctl restart cdi-health-api
+```
+
+Trusted lab networks only.
+
+For **dashboard + mock demo** on a laptop, use **Option A (Docker Compose)** with the host overlay for discovery, or `./scripts/start-local-mock.sh` from a dev clone.
 
 ---
 

--- a/scripts/docker-up.sh
+++ b/scripts/docker-up.sh
@@ -11,12 +11,14 @@ Usage: ./scripts/docker-up.sh [options] [compose args...]
 Start the CDI Health API + dashboard with Docker Compose (mock/demo by default).
 
 Options:
+  --host       API on host network for LAN discovery (remote grading benches)
   --hardware   Include hardware overlay for live drive scanning on the host
   --build      Pass --build to compose up
   -h, --help   Show this help
 
 Examples:
   ./scripts/docker-up.sh --build
+  ./scripts/docker-up.sh --host --build
   ./scripts/docker-up.sh --hardware --build
   ./scripts/docker-up.sh down
 
@@ -25,11 +27,16 @@ USAGE
 }
 
 HARDWARE=0
+HOST=0
 BUILD=0
 COMPOSE_ARGS=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+  --host)
+    HOST=1
+    shift
+    ;;
   --hardware)
     HARDWARE=1
     shift
@@ -48,6 +55,10 @@ while [[ $# -gt 0 ]]; do
     ;;
   esac
 done
+
+if [[ "$HOST" == "1" ]]; then
+  COMPOSE_FILES+=(-f "$ROOT_DIR/deploy/docker/docker-compose.host.yml")
+fi
 
 if [[ "$HARDWARE" == "1" ]]; then
   COMPOSE_FILES+=(-f "$ROOT_DIR/deploy/docker/docker-compose.hardware.yml")


### PR DESCRIPTION
## Summary
- Adds `docker-compose.host.yml` overlay so the API runs on the host network and **Discover** can probe the lab LAN for remote grading benches
- Dashboard proxies to the host API via `host.docker.internal`; adds `./scripts/docker-up.sh --host`
- Defaults published dashboard image to live-scan UI mode (`VITE_CDI_USE_MOCK_DATA=0`); mock demos still use API container fixtures
- Simplifies README and technician docs: mock Docker demo, LAN discovery overlay, and `.deb` for grading benches

## Test plan
- [ ] `CDI_VERSION=0.9.4 docker compose -f deploy/docker/docker-compose.ghcr.yml up -d` — mock demo at http://127.0.0.1:3000
- [ ] Same with `-f deploy/docker/docker-compose.host.yml` — Discover finds benches with API on `0.0.0.0:8844`
- [ ] `./scripts/docker-up.sh --host --build` — local build path works
- [ ] After merge, tag `v0.9.4` and verify GHCR images publish


Made with [Cursor](https://cursor.com)