### PR TITLE
Fix Docker host overlay for Mac/Linux

### DIFF
--- a/deploy/docker/docker-compose.host.yml
+++ b/deploy/docker/docker-compose.host.yml
@@ -1,5 +1,5 @@
 # Overlay: API uses the host network so LAN discovery sees lab interfaces.
-# Dashboard stays bridged and proxies to the API on the host via host.docker.internal.
+# Dashboard shares the API network namespace and proxies to 127.0.0.1:8844.
 #
 # Mock demo (default):
 #   docker compose -f deploy/docker/docker-compose.ghcr.yml up -d
@@ -8,8 +8,7 @@
 #   docker compose -f deploy/docker/docker-compose.ghcr.yml \
 #     -f deploy/docker/docker-compose.host.yml up -d
 #
-# Requires Docker Compose v2.1+ (host-gateway). Linux and Docker Desktop supported.
-# Ensure port 8844 is free on the host (stop local cdi-health-api if installed).
+# Open http://127.0.0.1:3000 — ensure port 8844 is free (stop local cdi-health-api if installed).
 
 services:
   api:
@@ -18,7 +17,7 @@ services:
       - cdi-api-data:/var/lib/cdi-health
 
   dashboard:
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+    network_mode: service:api
+    ports: !reset null
     volumes:
       - ./nginx.host.conf:/etc/nginx/conf.d/default.conf:ro

--- a/deploy/docker/nginx.host.conf
+++ b/deploy/docker/nginx.host.conf
@@ -1,12 +1,12 @@
 server {
-    listen 80;
+    listen 3000;
     server_name _;
 
     root /usr/share/nginx/html;
     index index.html;
 
     location /api/cdi/ {
-        proxy_pass http://host.docker.internal:8844/;
+        proxy_pass http://127.0.0.1:8844/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
- Dashboard shares API network namespace (`network_mode: service:api`) so nginx can proxy to `127.0.0.1:8844` on host network
- Clear published port mapping conflict with `ports: !reset null`
- nginx listens on 3000 when using host overlay

## Test plan
- [x] Mock GHCR stack on Mac — health + scan pass
- [x] Host overlay — health/discover/scan pass in-container on Docker Desktop Mac
- [ ] Linux host confirms `http://127.0.0.1:3000` reachable from host


Made with [Cursor](https://cursor.com)